### PR TITLE
Get rid of postinstall with bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "4"
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "jshint-groups **/* && jscs .",
-    "deps": "bower i",
-    "postinstall": "bower i",
+    "deps": "bower i --allow-root",
     "tmpl-specs": "magic run tmpl-specs",
-    "test": "npm run lint && npm run tmpl-specs"
+    "test": "npm run lint && npm run deps && npm run tmpl-specs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`bower` will install dependencies automatically. Otherwise if `npm` is used it's strange to force users to use `bower` anyways.